### PR TITLE
feat: 전역적으로 사용 가능한 모달 커스텀 훅 구현

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/react';
+import { ModalProps } from '@/types/common/modal';
+import theme from '@/styles/theme';
+import useModalStore from '@/stores/useModalStore';
+import CREATE_TEXTS from '@/constants/invitation/createTexts';
+
+function Modal({ onClick }: ModalProps) {
+  const { modalState, closeModal } = useModalStore();
+  const { modal } = CREATE_TEXTS;
+
+  return (
+    <div css={backgroundStyles}>
+      <div css={modalContainerStyles}>
+        <div className="title">{modalState.title}</div>
+        <div className="content">{modalState.content}</div>
+        <div css={btnWrapperStyles}>
+          <button type="button" className="send" onClick={onClick}>
+            {modal.button.send}
+          </button>
+          <button type="button" className="cancel" onClick={closeModal}>
+            {modal.button.cancel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const backgroundStyles = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1;
+`;
+
+const modalContainerStyles = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 8px;
+  width: 340px;
+  height: 176px;
+  border-radius: 16px;
+  background-color: ${theme.palette.white};
+  z-index: 1;
+
+  .title {
+    color: ${theme.palette.input.enabled};
+    font: ${theme.font.subTitle.subTitle1_600};
+    line-height: 18px;
+    padding: 20px 0 16px 20px;
+  }
+  .content {
+    height: 34px;
+    color: ${theme.palette.greyscale.grey60};
+    font: ${theme.font.body.body1_400};
+    line-height: 24px;
+    padding: 0 20px 0 20px;
+  }
+`;
+
+const btnWrapperStyles = css`
+  display: flex;
+  justify-content: flex-end;
+  gap: 40px;
+  width: 100%;
+  height: 64px;
+  padding-right: 30px;
+  font: ${theme.font.body.body1_500};
+  line-height: 24px;
+
+  .send {
+    color: ${theme.palette.primary};
+    cursor: pointer;
+  }
+  .cancel {
+    color: ${theme.palette.greyscale.grey50};
+    cursor: pointer;
+  }
+`;
+
+export default Modal;

--- a/src/constants/invitation/createTexts.ts
+++ b/src/constants/invitation/createTexts.ts
@@ -41,6 +41,20 @@ const CREATE_TEXTS = {
     name: '이름 입력',
     contact: '전화번호 입력',
   },
+  modal: {
+    send: {
+      title: '초대장 전송',
+      content: '초대장을 전송할까요?',
+    },
+    resend: {
+      title: '초대장 재전송',
+      content: '초대장을 이대로 수정하고 전송할까요?',
+    },
+    button: {
+      send: '전송하기',
+      cancel: '취소',
+    },
+  },
 };
 
 export default CREATE_TEXTS;

--- a/src/pages/invitation/index.tsx
+++ b/src/pages/invitation/index.tsx
@@ -1,57 +1,51 @@
 import Add from '@/components/common/Add';
-import Category from '@/components/common/Category';
 import Input from '@/components/common/Input';
 import NameTag from '@/components/common/NameTag';
 import { css } from '@emotion/react';
+import useModalStore from '@/stores/useModalStore';
+import Modal from '@/components/common/Modal';
+import CREATE_TEXTS from '@/constants/invitation/createTexts';
 
-function index() {
+function Index() {
+  const { modalState, openModal } = useModalStore();
+  const { modal } = CREATE_TEXTS;
+
+  const sendHandler = () => {
+    openModal(modal.send.title, modal.send.content);
+  };
+
+  const resendHandler = () => {
+    openModal(modal.resend.title, modal.resend.content);
+  };
+
   return (
     <>
-      <div
+      <button
+        type="button"
+        onClick={sendHandler}
         css={css`
-          // 확인용 스타일입니다. 추후 삭제 예정입니다.
-          display: flex;
-          flex-direction: column;
-          width: 100vw;
-          min-width: 280px;
-          max-width: 1024px;
-          padding-top: 10px;
-          margin-bottom: 20px;
-          gap: 20px;
+          width: 100px;
+          border: 1px solid pink;
+          border-radius: 10px;
+          background-color: pink;
         `}
       >
-        <div
-          css={css`
-            // 확인용 스타일입니다. 추후 삭제 예정입니다.
-            display: flex;
-            flex-shrink: flex;
-            gap: 10px;
-          `}
-        >
-          <Category icon="meeting" title="회의" variant="grey" />
-          <Category icon="interview" title="면접" variant="grey" />
-          <Category icon="fixedTermWork" title="기간근무" variant="grey" />
-          <Category icon="seminar" title="세미나" variant="grey" />
-          <Category icon="as" title="AS/점검" variant="grey" />
-          <Category icon="etc" title="직접 입력" variant="grey" />
-        </div>
+        모달 테스트
+      </button>
+      <button
+        type="button"
+        onClick={resendHandler}
+        css={css`
+          width: 140px;
+          border: 1px solid pink;
+          border-radius: 10px;
+          background-color: pink;
+        `}
+      >
+        모달 재전송 테스트
+      </button>
+      {modalState.isOpen && <Modal onClick={() => alert('전송예정!')} />}
 
-        <div
-          css={css`
-            // 확인용 스타일입니다. 추후 삭제 예정입니다.
-            display: flex;
-            flex-shrink: flex;
-            gap: 10px;
-          `}
-        >
-          <Category icon="meeting" title="회의" variant="blue" />
-          <Category icon="interview" title="면접" variant="blue" />
-          <Category icon="fixedTermWork" title="기간근무" variant="blue" />
-          <Category icon="seminar" title="세미나" variant="blue" />
-          <Category icon="as" title="AS/점검" variant="blue" />
-          <Category icon="etc" title="직접 입력" variant="blue" />
-        </div>
-      </div>
       <input type="text" placeholder="test" />
       {/* input default */}
       <Input variant="default" placeholder="inputText" />
@@ -84,4 +78,4 @@ function index() {
   );
 }
 
-export default index;
+export default Index;

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { ModalStoreTypes } from '@/types/common/modal';
+
+// 모달 초기값
+const initialModalState = {
+  isOpen: false,
+  title: null,
+  content: null,
+};
+
+const useModalStore = create<ModalStoreTypes>()((set) => ({
+  modalState: initialModalState,
+  openModal: (title, content) => {
+    set({ modalState: { isOpen: true, title, content } });
+  },
+  closeModal: () => {
+    set({ modalState: initialModalState });
+  },
+}));
+
+export default useModalStore;

--- a/src/types/common/modal.ts
+++ b/src/types/common/modal.ts
@@ -1,0 +1,17 @@
+// useModalStore.ts
+export interface ModalStoreTypes {
+  modalState: ModalStateTypes;
+  openModal: (title: string, content: string) => void;
+  closeModal: () => void;
+}
+
+export interface ModalStateTypes {
+  isOpen: boolean;
+  title: string | null;
+  content: string | null;
+}
+
+// Modal.tsx
+export interface ModalProps {
+  onClick: () => void;
+}

--- a/src/types/invitation/create.ts
+++ b/src/types/invitation/create.ts
@@ -17,6 +17,11 @@ export interface InvitationCreateTexts {
   placeholder: {
     [key: string]: string;
   };
+  modal: {
+    [key: string]: {
+      [key: string]: string;
+    };
+  };
 }
 
 // 초대 목적 선택


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

## 👩‍🎤 작업 내용
- 모달 컴포넌트 구현
- useModalStore 함수 생성

![modal-test](https://github.com/livable-final/client/assets/116873887/fcba8126-9e3e-4120-a452-05dc86bec07e)

## 🧚 관련 issue
#46 

## 🙋🏼 공유할 사항 및 질문 사항
전역적으로 사용 가능하도록 useModalStore 함수를 만들었습니다. 필요하신 분은 사용하세요!
아직까지는 모달 내부 버튼에 전송/취소를 고정으로 넣어뒀는데 다른 예외가 필요하시면 추후 수정하겠습니다.

```tsx
import useModalStore from '@/stores/useModalStore';
import Modal from '@/components/Modal';

function 모달을사용할컴포넌트() {
  const { modalState, openModal } = useModalStore();

  // 모달에 띄워줄 제목과 내용을 넣어줍니다.
  const onClickModal = () => {
    openModal('모달 제목', '모달 내용');
  }

  return (
      <button type="button" onClick={onClickModal}>
          누르면 모달이 띄워져요.
      </button>

      {modalState.isOpen && <Modal onClick={모달 내부 submit 버튼에 들어갈 함수} />
  );
}
```

```tsx
import useModalStore from '@/stores/useModalStore';
import CREATE_TEXTS from '@/constants/invitation/createTexts';

function Modal({ onClick }: ModalProps) {
  const { modalState, closeModal } = useModalStore();
  const { modal } = CREATE_TEXTS;

  return (
    <div css={backgroundStyles}>
      <div css={modalContainerStyles}>
        {/*openMoal() 함수로 넣은 모달 제목과 내용이 들어갑니다.*/}
        <div className="title">{modalState.title}</div>
        <div className="content">{modalState.content}</div>
        <div css={btnWrapperStyles}>
          {/*Modal 컴포넌트에 props로 내려준 onClick 함수가 반영됩니다.*/}
          <button type="button" className="send" onClick={onClick}>
            {modal.button.send}
          </button>
          <button type="button" className="cancel" onClick={closeModal}>
            {modal.button.cancel}
          </button>
        </div>
      </div>
    </div>
  );
}
```