### PR TITLE
feat: 전역 사용 가능한 모달 커스텀 훅 구현 (alert, confirm 버전 포함)

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/react';
+import { ModalProps } from '@/types/common/modal';
+import theme from '@/styles/theme';
+import useModalStore from '@/stores/useModalStore';
+import CREATE_TEXTS from '@/constants/invitation/createTexts';
+
+function Modal({ onClick }: ModalProps) {
+  const { modalState, closeModal } = useModalStore();
+  const { modal } = CREATE_TEXTS;
+
+  return (
+    <div css={backgroundStyles}>
+      <div css={modalContainerStyles}>
+        <div className="title">{modalState.title}</div>
+        <div className="content">{modalState.content}</div>
+        <div css={btnWrapperStyles}>
+          <button type="button" className="send" onClick={onClick}>
+            {modal.button.send}
+          </button>
+          <button type="button" className="cancel" onClick={closeModal}>
+            {modal.button.cancel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const backgroundStyles = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1;
+`;
+
+const modalContainerStyles = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 8px;
+  width: 340px;
+  height: 176px;
+  border-radius: 16px;
+  background-color: ${theme.palette.white};
+  z-index: 1;
+
+  .title {
+    color: ${theme.palette.input.enabled};
+    font: ${theme.font.subTitle.subTitle1_600};
+    line-height: 18px;
+    padding: 20px 0 16px 20px;
+  }
+  .content {
+    height: 34px;
+    color: ${theme.palette.greyscale.grey60};
+    font: ${theme.font.body.body1_400};
+    line-height: 24px;
+    padding: 0 20px 0 20px;
+  }
+`;
+
+const btnWrapperStyles = css`
+  display: flex;
+  justify-content: flex-end;
+  gap: 40px;
+  width: 100%;
+  height: 64px;
+  padding-right: 30px;
+  font: ${theme.font.body.body1_500};
+  line-height: 24px;
+
+  .send {
+    color: ${theme.palette.primary};
+    cursor: pointer;
+  }
+  .cancel {
+    color: ${theme.palette.greyscale.grey50};
+    cursor: pointer;
+  }
+`;
+
+export default Modal;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -2,24 +2,41 @@ import { css } from '@emotion/react';
 import { ModalProps } from '@/types/common/modal';
 import theme from '@/styles/theme';
 import useModalStore from '@/stores/useModalStore';
-import CREATE_TEXTS from '@/constants/invitation/createTexts';
+import { COMMON_MODAL_BUTTONS } from '@/constants/common';
 
-function Modal({ onClick }: ModalProps) {
+function Modal({ isAlert, isConfirm, onClick }: ModalProps) {
   const { modalState, closeModal } = useModalStore();
-  const { modal } = CREATE_TEXTS;
+  const { confirm, cancel, send } = COMMON_MODAL_BUTTONS;
 
   return (
     <div css={backgroundStyles}>
       <div css={modalContainerStyles}>
-        <div className="title">{modalState.title}</div>
-        <div className="content">{modalState.content}</div>
+        <div css={modalTitleStyles}>{modalState.title}</div>
+        <div css={modalContentStyles}>{modalState.content}</div>
         <div css={btnWrapperStyles}>
-          <button type="button" className="send" onClick={onClick}>
-            {modal.button.send}
-          </button>
-          <button type="button" className="cancel" onClick={closeModal}>
-            {modal.button.cancel}
-          </button>
+          {isAlert ? (
+            <button type="button" css={defaultBtnStyles} onClick={closeModal}>
+              {confirm}
+            </button>
+          ) : isConfirm ? (
+            <>
+              <button type="button" css={defaultBtnStyles} onClick={onClick}>
+                {confirm}
+              </button>
+              <button type="button" css={cancelBtnStyles} onClick={closeModal}>
+                {cancel}
+              </button>
+            </>
+          ) : (
+            <>
+              <button type="button" css={defaultBtnStyles}>
+                {send}
+              </button>
+              <button type="button" css={cancelBtnStyles} onClick={closeModal}>
+                {cancel}
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>
@@ -50,20 +67,22 @@ const modalContainerStyles = css`
   border-radius: 16px;
   background-color: ${theme.palette.white};
   z-index: 1;
+`;
 
-  .title {
-    color: ${theme.palette.input.enabled};
-    font: ${theme.font.subTitle.subTitle1_600};
-    line-height: 18px;
-    padding: 20px 0 16px 20px;
-  }
-  .content {
-    height: 34px;
-    color: ${theme.palette.greyscale.grey60};
-    font: ${theme.font.body.body1_400};
-    line-height: 24px;
-    padding: 0 20px 0 20px;
-  }
+const modalTitleStyles = css`
+  padding: 20px 0 16px 20px;
+  color: ${theme.palette.input.enabled};
+  font: ${theme.font.subTitle.subTitle1_600};
+  line-height: 18px;
+`;
+
+const modalContentStyles = css`
+  height: 34px;
+  padding: 0 20px 0 20px;
+  white-space: pre-wrap;
+  color: ${theme.palette.greyscale.grey60};
+  font: ${theme.font.body.body1_400};
+  line-height: 24px;
 `;
 
 const btnWrapperStyles = css`
@@ -75,15 +94,16 @@ const btnWrapperStyles = css`
   padding-right: 30px;
   font: ${theme.font.body.body1_500};
   line-height: 24px;
+`;
 
-  .send {
-    color: ${theme.palette.primary};
-    cursor: pointer;
-  }
-  .cancel {
-    color: ${theme.palette.greyscale.grey50};
-    cursor: pointer;
-  }
+const defaultBtnStyles = css`
+  color: ${theme.palette.primary};
+  cursor: pointer;
+`;
+
+const cancelBtnStyles = css`
+  color: ${theme.palette.greyscale.grey50};
+  cursor: pointer;
 `;
 
 export default Modal;

--- a/src/components/invitation/create/InvitationNameList.tsx
+++ b/src/components/invitation/create/InvitationNameList.tsx
@@ -15,8 +15,8 @@ function InvitationNameList({ nameList }: InvitationNameListProps) {
   return (
     <div css={listContainerStyles}>
       <div css={titleWrapperStyles}>
-        <div className="title">{title.invitationList}</div>
-        <div className="length">{nameList.length}/30</div>
+        <div css={titleStyles}>{title.invitationList}</div>
+        <div css={lengthStyles}>{nameList.length}/30</div>
       </div>
       <div css={listWrapperStyles}>
         <Add isBlue onClick={() => alert('추가 버튼 테스트')} />
@@ -53,17 +53,18 @@ const listContainerStyles = css`
 const titleWrapperStyles = css`
   display: flex;
   justify-content: space-between;
+`;
 
-  .title {
-    font: ${theme.font.subTitle.subTitle1_600};
-    color: ${theme.palette.title};
-    line-height: 25px;
-  }
-  .length {
-    font: ${theme.font.body.body1_400};
-    color: ${theme.palette.greyscale.grey40};
-    line-height: 24px;
-  }
+const titleStyles = css`
+  font: ${theme.font.subTitle.subTitle1_600};
+  color: ${theme.palette.title};
+  line-height: 25px;
+`;
+
+const lengthStyles = css`
+  font: ${theme.font.body.body1_400};
+  color: ${theme.palette.greyscale.grey40};
+  line-height: 24px;
 `;
 
 const listWrapperStyles = css`

--- a/src/components/invitation/create/InvitationPurposeContainer.tsx
+++ b/src/components/invitation/create/InvitationPurposeContainer.tsx
@@ -29,17 +29,17 @@ function InvitationPurpose() {
       </div>
       <div css={categoryContainerStyles}>
         <div css={categoryWrapperStyles}>
-          {categories.map((value) => (
+          {categories.map((item) => (
             <button
-              key={value.icon}
+              key={item.icon}
               type="button"
-              onClick={() => setSelectedCategory(value.icon)}
+              onClick={() => setSelectedCategory(item.icon)}
             >
               <Category
-                key={value.icon}
-                icon={value.icon}
-                title={value.title}
-                variant={selectedCategory === value.icon ? 'blue' : 'grey'}
+                key={item.icon}
+                icon={item.icon}
+                title={item.title}
+                variant={selectedCategory === item.icon ? 'blue' : 'grey'}
               />
             </button>
           ))}

--- a/src/constants/common/index.ts
+++ b/src/constants/common/index.ts
@@ -118,4 +118,12 @@ export const COMMON_CATEGORIES = {
   },
 };
 
+// 토글 버튼
 export const COMMON_TOGGLE_TITLE = '종일';
+
+// 모달 내부 버튼
+export const COMMON_MODAL_BUTTONS = {
+  confirm: '확인',
+  cancel: '취소',
+  send: '전송하기',
+};

--- a/src/constants/invitation/createTexts.ts
+++ b/src/constants/invitation/createTexts.ts
@@ -50,10 +50,6 @@ const CREATE_TEXTS = {
       title: '초대장 재전송',
       content: '초대장을 이대로 수정하고 전송할까요?',
     },
-    button: {
-      send: '전송하기',
-      cancel: '취소',
-    },
   },
 };
 

--- a/src/constants/invitation/createTexts.ts
+++ b/src/constants/invitation/createTexts.ts
@@ -41,6 +41,20 @@ const CREATE_TEXTS = {
     name: '이름 입력',
     contact: '전화번호 입력',
   },
+  modal: {
+    send: {
+      title: '초대장 전송',
+      content: '초대장을 전송할까요?',
+    },
+    resend: {
+      title: '초대장 재전송',
+      content: '초대장을 이대로 수정하고 전송할까요?',
+    },
+    button: {
+      send: '전송하기',
+      cancel: '취소',
+    },
+  },
 };
 
 export default CREATE_TEXTS;

--- a/src/pages/invitation/index.tsx
+++ b/src/pages/invitation/index.tsx
@@ -10,11 +10,11 @@ function Index() {
   const { modalState, openModal } = useModalStore();
   const { modal } = CREATE_TEXTS;
 
-  const sendHandler = () => {
+  const onClickSendHandler = () => {
     openModal(modal.send.title, modal.send.content);
   };
 
-  const resendHandler = () => {
+  const onClickResendHandler = () => {
     openModal(modal.resend.title, modal.resend.content);
   };
 
@@ -22,7 +22,7 @@ function Index() {
     <>
       <button
         type="button"
-        onClick={sendHandler}
+        onClick={onClickSendHandler}
         css={css`
           width: 100px;
           border: 1px solid pink;
@@ -34,7 +34,7 @@ function Index() {
       </button>
       <button
         type="button"
-        onClick={resendHandler}
+        onClick={onClickResendHandler}
         css={css`
           width: 140px;
           border: 1px solid pink;

--- a/src/pages/invitation/index.tsx
+++ b/src/pages/invitation/index.tsx
@@ -1,57 +1,51 @@
 import Add from '@/components/common/Add';
-import Category from '@/components/common/Category';
 import Input from '@/components/common/Input';
 import NameTag from '@/components/common/NameTag';
 import { css } from '@emotion/react';
+import useModalStore from '@/stores/useModalStore';
+import Modal from '@/components/common/Modal';
+import CREATE_TEXTS from '@/constants/invitation/createTexts';
 
-function index() {
+function Index() {
+  const { modalState, openModal } = useModalStore();
+  const { modal } = CREATE_TEXTS;
+
+  const sendHandler = () => {
+    openModal(modal.send.title, modal.send.content);
+  };
+
+  const resendHandler = () => {
+    openModal(modal.resend.title, modal.resend.content);
+  };
+
   return (
     <>
-      <div
+      <button
+        type="button"
+        onClick={sendHandler}
         css={css`
-          // 확인용 스타일입니다. 추후 삭제 예정입니다.
-          display: flex;
-          flex-direction: column;
-          width: 100vw;
-          min-width: 280px;
-          max-width: 1024px;
-          padding-top: 10px;
-          margin-bottom: 20px;
-          gap: 20px;
+          width: 100px;
+          border: 1px solid pink;
+          border-radius: 10px;
+          background-color: pink;
         `}
       >
-        <div
-          css={css`
-            // 확인용 스타일입니다. 추후 삭제 예정입니다.
-            display: flex;
-            flex-shrink: flex;
-            gap: 10px;
-          `}
-        >
-          <Category icon="meeting" title="회의" variant="grey" />
-          <Category icon="interview" title="면접" variant="grey" />
-          <Category icon="fixedTermWork" title="기간근무" variant="grey" />
-          <Category icon="seminar" title="세미나" variant="grey" />
-          <Category icon="as" title="AS/점검" variant="grey" />
-          <Category icon="etc" title="직접 입력" variant="grey" />
-        </div>
+        모달 테스트
+      </button>
+      <button
+        type="button"
+        onClick={resendHandler}
+        css={css`
+          width: 140px;
+          border: 1px solid pink;
+          border-radius: 10px;
+          background-color: pink;
+        `}
+      >
+        모달 재전송 테스트
+      </button>
+      {modalState.isOpen && <Modal onClick={() => alert('전송예정!')} />}
 
-        <div
-          css={css`
-            // 확인용 스타일입니다. 추후 삭제 예정입니다.
-            display: flex;
-            flex-shrink: flex;
-            gap: 10px;
-          `}
-        >
-          <Category icon="meeting" title="회의" variant="blue" />
-          <Category icon="interview" title="면접" variant="blue" />
-          <Category icon="fixedTermWork" title="기간근무" variant="blue" />
-          <Category icon="seminar" title="세미나" variant="blue" />
-          <Category icon="as" title="AS/점검" variant="blue" />
-          <Category icon="etc" title="직접 입력" variant="blue" />
-        </div>
-      </div>
       <input type="text" placeholder="test" />
       {/* input default */}
       <Input variant="default" placeholder="inputText" />
@@ -84,4 +78,4 @@ function index() {
   );
 }
 
-export default index;
+export default Index;

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { ModalStoreTypes } from '@/types/common/modal';
+
+// 모달 초기값
+const initialModalState = {
+  isOpen: false,
+  title: null,
+  content: null,
+};
+
+const useModalStore = create<ModalStoreTypes>()((set) => ({
+  modalState: initialModalState,
+  openModal: (title, content) => {
+    set({ modalState: { isOpen: true, title, content } });
+  },
+  closeModal: () => {
+    set({ modalState: initialModalState });
+  },
+}));
+
+export default useModalStore;

--- a/src/types/common/modal.ts
+++ b/src/types/common/modal.ts
@@ -1,17 +1,19 @@
 // useModalStore.ts
 export interface ModalStoreTypes {
   modalState: ModalStateTypes;
-  openModal: (title: string, content: string) => void;
+  openModal: (title: string, content: string | JSX.Element) => void;
   closeModal: () => void;
 }
 
 export interface ModalStateTypes {
   isOpen: boolean;
   title: string | null;
-  content: string | null;
+  content: string | JSX.Element | null;
 }
 
 // Modal.tsx
 export interface ModalProps {
-  onClick: () => void;
+  isAlert?: boolean;
+  isConfirm?: boolean;
+  onClick?: () => void;
 }

--- a/src/types/common/modal.ts
+++ b/src/types/common/modal.ts
@@ -1,0 +1,17 @@
+// useModalStore.ts
+export interface ModalStoreTypes {
+  modalState: ModalStateTypes;
+  openModal: (title: string, content: string) => void;
+  closeModal: () => void;
+}
+
+export interface ModalStateTypes {
+  isOpen: boolean;
+  title: string | null;
+  content: string | null;
+}
+
+// Modal.tsx
+export interface ModalProps {
+  onClick: () => void;
+}

--- a/src/types/invitation/create.ts
+++ b/src/types/invitation/create.ts
@@ -17,6 +17,11 @@ export interface InvitationCreateTexts {
   placeholder: {
     [key: string]: string;
   };
+  modal: {
+    [key: string]: {
+      [key: string]: string;
+    };
+  };
 }
 
 // 초대 목적 선택


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

## 👩‍🎤 작업 내용
- 모달 컴포넌트 구현 (alert, confirm 버전이 포함되었습니다.)
- useModalStore 함수 생성

![modal-test](https://github.com/livable-final/client/assets/116873887/fcba8126-9e3e-4120-a452-05dc86bec07e)
![modal-alert](https://github.com/livable-final/client/assets/116873887/4ff67af2-bbf7-4be3-a12c-7ad3dbc1504e)
![modal-confirm](https://github.com/livable-final/client/assets/116873887/aa66e9b5-ef28-40fa-9922-c46ba0d90ba7)


## 🧚 관련 issue
#46 

## 🙋🏼 공유할 사항 및 질문 사항
전역적으로 사용 가능하도록 useModalStore 함수를 만들었습니다.
alert, confirm 버전에는 isAlert, isConfirm props를 전달하여 사용하시면 됩니다.
궁금한 점이나 개선사항 있다면 말씀 주세요!!

```tsx
import useModalStore from '@/stores/useModalStore';
import Modal from '@/components/Modal';

function 모달을사용할컴포넌트() {
  const { modalState, openModal } = useModalStore();

  // 모달에 띄워줄 제목과 내용을 넣어줍니다.
  const onClickModal = () => {
    openModal('모달 제목', '모달 내용');
  }

  return (
      <button type="button" onClick={onClickModal}>
          누르면 모달이 띄워져요.
      </button>

      {modalState.isOpen && <Modal onClick={모달 내부 버튼에 들어갈 함수} />
      {modalState.isOpen && <Modal isAlert />
      {modalState.isOpen && <Modal isConfirm onClick={모달 내부 버튼에 들어갈 함수} />
  );
}
```