### PR TITLE
feat: 전역 사용 가능한 BottomSheet 구현

### DIFF
--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -2,22 +2,19 @@ import { css } from '@emotion/react';
 import { BottomSheetProps } from '@/types/common/bottomSheet';
 import theme from '@/styles/theme';
 import Button from '@/components/common/Button';
+import useBottomSheetStore from '@/stores/useBottomSheetStore';
 
-function BottomSheet({ isOpen, setIsOpen }: BottomSheetProps) {
+function BottomSheet({ onClick }: BottomSheetProps) {
+  const { bottomSheetState, closeBottomSheet } = useBottomSheetStore();
+  const { isOpen } = bottomSheetState;
+
   // 바텀시트 바깥쪽 누를 때 닫기
   const onClickBackgroundHandler = (
     e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
   ) => {
     if (e.target === e.currentTarget) {
-      setIsOpen(!isOpen);
-      console.log(isOpen);
+      closeBottomSheet();
     }
-  };
-
-  // 바텀시트 내부 버튼 클릭했을 때 닫기
-  const onClickInsideBtnHandler = () => {
-    setIsOpen(!isOpen);
-    console.log(isOpen);
   };
 
   return (
@@ -29,20 +26,9 @@ function BottomSheet({ isOpen, setIsOpen }: BottomSheetProps) {
       tabIndex={0}
     >
       <div css={containerStyles(isOpen)}>
-        <div
-          css={css`
-            width: 100%;
-            padding: 0 16px;
-          `}
-        >
-          <input type="text" placeholder="바텀시트 테스트입니다." />
-        </div>
+        {bottomSheetState.content}
         <div css={buttonWrapperStyles}>
-          <Button
-            content="저장"
-            variant="blue"
-            onClick={onClickInsideBtnHandler}
-          />
+          <Button content="저장" variant="blue" onClick={onClick} />
         </div>
       </div>
     </div>
@@ -72,6 +58,7 @@ const containerStyles = (isOpen: boolean) => css`
   border-radius: 20px 20px 0 0;
   width: 100%;
   min-height: 400px;
+  height: auto;
   background-color: ${theme.palette.white};
   animation: ${isOpen
     ? `bottomSheetUp 800ms ease-out`

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,0 +1,107 @@
+import { css } from '@emotion/react';
+import { BottomSheetProps } from '@/types/common/bottomSheet';
+import theme from '@/styles/theme';
+import Button from '@/components/common/Button';
+
+function BottomSheet({ isOpen, setIsOpen }: BottomSheetProps) {
+  // 바텀시트 바깥쪽 누를 때 닫기
+  const onClickBackgroundHandler = (
+    e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (e.target === e.currentTarget) {
+      setIsOpen(!isOpen);
+      console.log(isOpen);
+    }
+  };
+
+  // 바텀시트 내부 버튼 클릭했을 때 닫기
+  const onClickInsideBtnHandler = () => {
+    setIsOpen(!isOpen);
+    console.log(isOpen);
+  };
+
+  return (
+    <div
+      css={backgroundStyles(isOpen)}
+      onClick={onClickBackgroundHandler}
+      onKeyDown={onClickBackgroundHandler}
+      role="button"
+      tabIndex={0}
+    >
+      <div css={containerStyles(isOpen)}>
+        <div
+          css={css`
+            width: 100%;
+            padding: 0 16px;
+          `}
+        >
+          <input type="text" placeholder="바텀시트 테스트입니다." />
+        </div>
+        <div css={buttonWrapperStyles}>
+          <Button
+            content="저장"
+            variant="blue"
+            onClick={onClickInsideBtnHandler}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const backgroundStyles = (isOpen: boolean) => css`
+  display: ${isOpen ? 'block' : 'none'};
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  background-color: ${isOpen ? `rgba(0, 0, 0, 0.3)` : `none`};
+`;
+
+const containerStyles = (isOpen: boolean) => css`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 28px;
+  border: 1px solid ${theme.palette.greyscale.grey20};
+  border-radius: 20px 20px 0 0;
+  width: 100%;
+  min-height: 400px;
+  background-color: ${theme.palette.white};
+  animation: ${isOpen
+    ? `bottomSheetUp 800ms ease-out`
+    : `bottomSheetDown 800ms ease-out`};
+  z-index: 1;
+
+  @keyframes bottomSheetUp {
+    0% {
+      transform: translateY(100%);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes bottomSheetDown {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(100%);
+    }
+  }
+`;
+
+const buttonWrapperStyles = css`
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: 0 16px;
+  margin-bottom: 30px;
+`;
+export default BottomSheet;

--- a/src/components/invitation/create/InvitationInfoContainer.tsx
+++ b/src/components/invitation/create/InvitationInfoContainer.tsx
@@ -8,7 +8,7 @@ import InvitationNameList from '@/components/invitation/create/InvitationNameLis
 import { InvitationCreateTexts } from '@/types/invitation/create';
 import AddressBook from '@/components/common/AddressBook';
 
-function InvitationInfo() {
+function InvitationInfoContainer() {
   const { title, placeholder }: InvitationCreateTexts = CREATE_TEXTS;
   const nameList = ['고애신', '유진초이', '쿠도히나', '구동매', '김희성'];
 
@@ -91,4 +91,4 @@ const addBtnStyles = css`
   align-items: center;
 `;
 
-export default InvitationInfo;
+export default InvitationInfoContainer;

--- a/src/components/invitation/create/InvitationPurposeContainer.tsx
+++ b/src/components/invitation/create/InvitationPurposeContainer.tsx
@@ -13,7 +13,7 @@ import {
 import mq from '@/utils/mediaquery';
 import Input from '@/components/common/Input';
 
-function InvitationPurpose() {
+function InvitationPurposeContainer() {
   const { invitation }: CategoryInvitation = COMMON_CATEGORIES;
   const { title, description, placeholder }: InvitationCreateTexts =
     CREATE_TEXTS;
@@ -183,4 +183,4 @@ const inputWrapperStyles = css`
   }
 `;
 
-export default InvitationPurpose;
+export default InvitationPurposeContainer;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,8 @@ import RadioBtn from '@/components/common/RadioBtn';
 import InvitationFindRoadBtn from '@/components/invitation/view/InvitationFindRoadBtn';
 import CheckBox from '@/components/common/CheckBox';
 import Roulette from '@/components/Roulette';
+import BottomSheet from '@/components/common/BottomSheet';
+import useBottomSheetStore from '@/stores/useBottomSheetStore';
 
 function Home() {
   const onClickHandler = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -15,6 +17,14 @@ function Home() {
 
   // RadioBtn 예시 데이터, API 확인 후 변경 예정
   const arr = ['test1', 'test2', 'test3'];
+
+  // BottomSheet 테스트
+  const { bottomSheetState, openBottomSheet } = useBottomSheetStore();
+
+  const onClickBottomSheetHandler = () => {
+    openBottomSheet(<div>테스트입니다.</div>);
+  };
+
   return (
     <>
       <Head>
@@ -46,6 +56,11 @@ function Home() {
       <Toggle />
       <Roulette />
       <InvitationFindRoadBtn />
+
+      <button type="button" onClick={onClickBottomSheetHandler}>
+        누르면 바텀시트가 열립니다.
+      </button>
+      {bottomSheetState.isOpen && <BottomSheet />}
     </>
   );
 }

--- a/src/stores/useBottomSheetStore.ts
+++ b/src/stores/useBottomSheetStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import {
+  BottomSheetState,
+  BottomSheetStateTypes,
+} from '@/types/common/bottomSheet';
+
+const initialBottomSheetState: BottomSheetStateTypes = {
+  isOpen: false,
+  content: null,
+};
+
+const useBottomSheetStore = create<BottomSheetState>((set) => ({
+  bottomSheetState: initialBottomSheetState,
+  openBottomSheet: (content) =>
+    set({ bottomSheetState: { isOpen: true, content } }),
+  closeBottomSheet: () => set({ bottomSheetState: initialBottomSheetState }),
+}));
+
+export default useBottomSheetStore;

--- a/src/types/common/bottomSheet.ts
+++ b/src/types/common/bottomSheet.ts
@@ -1,0 +1,4 @@
+export interface BottomSheetProps {
+  isOpen: boolean;
+  setIsOpen: (v: boolean) => void;
+}

--- a/src/types/common/bottomSheet.ts
+++ b/src/types/common/bottomSheet.ts
@@ -1,4 +1,16 @@
-export interface BottomSheetProps {
+// useBottomSheetStore.ts
+export interface BottomSheetState {
+  bottomSheetState: BottomSheetStateTypes;
+  openBottomSheet: (content: React.ReactNode) => void;
+  closeBottomSheet: () => void;
+}
+
+export interface BottomSheetStateTypes {
   isOpen: boolean;
-  setIsOpen: (v: boolean) => void;
+  content: React.ReactNode | string | null;
+}
+
+// BottomSheet.tsx
+export interface BottomSheetProps {
+  onClick?: () => void;
 }


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [x] 사소한 수정

## 👩‍🎤 작업 내용
- 바텀시트 컴포넌트 구현 (+ 반응형)
- useBottomSheet 함수 생성 (전역 사용 및 내부 콘텐츠에 컴포넌트 할당 가능)
- 일부 컴포넌트 선언 코드 수정

![bottomSheet-test](https://github.com/livable-final/client/assets/116873887/231af0e4-48dd-4f5e-b710-39b912c262f4)


## 🧚 관련 issue
#32 

## 🙋🏼 공유할 사항 및 질문 사항
- 위 이미지 예시는 컴포넌트 전달이 가능하다는 이해를 돕기 위해 이미 완성된 컴포넌트를 임의로 넣어두었습니다.
- 백그라운드를 누르면 바텀시트가 자연스럽게 내려가는 애니메이션을 구현하고 싶었으나, 현재는 `display: none;`이 되면서 한 번에 사라집니다.
- 해당 애니메이션을 구현하기 위해서는 `display: block;` 으로 고정하고 전달되는 컴포넌트마다 height 값을 통해 뷰포트 바깥으로 내려줘야할 거 같은데(?) 해당 부분 로직을 구현하지 못했습니다. 좋은 아이디어 있으신 분은 의견 주시면 시도해보겠습니다. 🙏