### PR TITLE
feat: 임시 로그인 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,8 @@ const nextConfig = {
     API_BASE_URL: process.env.NEXT_PUBLIC_API_URL,
     WEATHER_API_KEY: process.env.WEATHER_API_KEY,
     WEATHER_BASE_URL: process.env.WEATHER_BASE_URL,
+    MEMBER_TOKEN: process.env.NEXT_MEMBER_TOKEN,
+    VISITOR_TOKEN: process.env.NEXT_VISITOR_TOKEN,
   },
 };
 

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,0 +1,85 @@
+import mq from '@/utils/mediaquery';
+import Category from '@/components/common/Category';
+import useViewStore from '@/stores/usePagesStore';
+import { css } from '@emotion/react';
+import { COMMON_USER_NAME } from '@/constants/common';
+import COMPONENT_NAME from '@/constants/common/pages';
+import useSaveStore from '@/stores/useSaveStore';
+
+function AuthForm() {
+  const MEMBER_TOKEN = process.env.MEMBER_TOKEN as string;
+  const { setNextComponent } = useViewStore();
+  const { setUserToken } = useSaveStore();
+
+  const onClickCategoryHandler = () => {
+    setNextComponent(COMPONENT_NAME.common.home);
+    setUserToken(MEMBER_TOKEN);
+  };
+
+  return (
+    <div css={purposeContainerStyles}>
+      <div css={categoryContainerStyles}>
+        <div css={categoryWrapperStyles}>
+          {COMMON_USER_NAME.map((item) => (
+            <button key={item} type="button" onClick={onClickCategoryHandler}>
+              <Category
+                key={item}
+                icon="fixedTermWork"
+                title={item}
+                variant="grey"
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const purposeContainerStyles = css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  max-width: 230px;
+
+  ${mq.lg} {
+    max-width: 640px;
+  }
+  ${mq.tab} {
+    max-width: 1024px;
+  }
+`;
+
+const categoryContainerStyles = css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`;
+
+const categoryWrapperStyles = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  min-width: 280px;
+  max-width: 360px;
+  padding: 0 4px 0;
+
+  ${mq.md} {
+    max-width: 360px;
+  }
+  ${mq.lg} {
+    max-width: 360px;
+  }
+  ${mq.tab} {
+    max-width: 480px;
+  }
+`;
+
+export default AuthForm;

--- a/src/components/common/Category.tsx
+++ b/src/components/common/Category.tsx
@@ -30,6 +30,17 @@ const CategoryContainer = (variantData: CategoryColorProps) => css`
   background-color: ${variantData.backgroundColor};
   cursor: pointer;
 
+  &:hover {
+    border: ${COMMON_CATEGORY_COLORS.hoveredBlue.border};
+
+    > div {
+      color: ${COMMON_CATEGORY_COLORS.hoveredBlue.color};
+    }
+    > div > svg {
+      color: ${COMMON_CATEGORY_COLORS.hoveredBlue.color};
+    }
+  }
+
   ${mq.tab} {
     width: 140px;
   }

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -24,7 +24,7 @@ function Title({ title, isMain, part }: TitleProps) {
       case 'user':
         return <Setting />;
       default:
-        return <Icons icon="down" />;
+        return null;
     }
   };
 

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -1,0 +1,26 @@
+import Bnb from '@/components/common/Bnb';
+import Title from '@/components/common/Title';
+import HomeContents from '@/components/home/HomeContents';
+import { DUMMY_RESPONSE } from '@/constants/home/homeTexts';
+import theme from '@/styles/theme';
+import { css } from '@emotion/react';
+import React from 'react';
+
+function Home() {
+  return (
+    <>
+      <Title title={DUMMY_RESPONSE.buildingName} part="main" isMain />
+      <div css={containerStyles}>
+        <HomeContents />
+      </div>
+      <Bnb />
+    </>
+  );
+}
+
+const containerStyles = css`
+  margin: 0 -16px 90px;
+  background: ${theme.palette.background.home};
+`;
+
+export default Home;

--- a/src/constants/common/index.ts
+++ b/src/constants/common/index.ts
@@ -38,6 +38,11 @@ export const COMMON_CATEGORY_COLORS: CategoryColorsProps = {
     backgroundColor: `${theme.palette.white}`,
     color: `${theme.palette.greyscale.grey40}`,
   },
+  hoveredBlue: {
+    border: `2px solid ${theme.palette.bluescale.blue30}`,
+    backgroundColor: `${theme.palette.white}`,
+    color: `${theme.palette.bluescale.blue30}`,
+  },
 };
 
 // Input box 스타일
@@ -166,6 +171,14 @@ export const COMMON_CATEGORIES = {
     },
   },
 };
+
+export const COMMON_USER_NAME = [
+  '유희태',
+  '이시우',
+  '김진우',
+  '김준희',
+  '조은상',
+];
 
 // 토글 버튼
 export const COMMON_TOGGLE_TITLE = '종일';

--- a/src/constants/common/pages.ts
+++ b/src/constants/common/pages.ts
@@ -1,0 +1,30 @@
+const COMPONENT_NAME = {
+  invitation: {
+    create: {
+      visiors: 'InvitationVisitorsContainer',
+      info: 'InvitationInfoContainer',
+      done: 'InvitationDoneContainer',
+      purpose: 'InvitationPurposeContainer',
+    },
+    view: {},
+  },
+  lunch: {
+    calendar: {
+      review: 'LunchCalendarReview',
+      menu: 'LunchCalendarMenu',
+      search: 'LunchCalendarSearch',
+      cafeteria: 'LunchCalendarCafeteria',
+      lunchBox: 'LunchCalendarLunchBox',
+    },
+    detail: {
+      detail: 'LunchDetail',
+      reviewByRanking: 'LunchReviewsByRanking',
+    },
+  },
+  common: {
+    signIn: 'SignIn',
+    home: 'home',
+  },
+};
+
+export default COMPONENT_NAME;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import AuthForm from '@/components/auth/AuthForm';
-import useViewStore from '@/stores/usePagesStore';
+import usePagesStore from '@/stores/usePagesStore';
 import mq from '@/utils/mediaquery';
 import { css } from '@emotion/react';
 import Home from '@/components/home';
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
 import Title from '@/components/common/Title';
 
 function Main() {
-  const { nextComponent } = useViewStore();
+  const { nextComponent } = usePagesStore();
   const { home } = COMPONENT_NAME.common;
   const [userToken, setUserToken] = useState<string | null>(null);
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,26 +1,53 @@
-import Bnb from '@/components/common/Bnb';
-import Title from '@/components/common/Title';
-import HomeContents from '@/components/home/HomeContents';
-import { DUMMY_RESPONSE } from '@/constants/home/homeTexts';
-import theme from '@/styles/theme';
+import AuthForm from '@/components/auth/AuthForm';
+import useViewStore from '@/stores/usePagesStore';
+import mq from '@/utils/mediaquery';
 import { css } from '@emotion/react';
-import React from 'react';
+import Home from '@/components/home';
+import COMPONENT_NAME from '@/constants/common/pages';
+import { useEffect, useState } from 'react';
+import Title from '@/components/common/Title';
 
-function Home() {
+function Main() {
+  const { nextComponent } = useViewStore();
+  const { home } = COMPONENT_NAME.common;
+  const [userToken, setUserToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('user');
+    setUserToken(token);
+  }, []);
+
+  if (nextComponent === home || userToken) {
+    return <Home />;
+  }
+
   return (
-    <>
-      <Title title={DUMMY_RESPONSE.buildingName} part="main" isMain />
-      <div css={containerStyles}>
-        <HomeContents />
-      </div>
-      <Bnb />
-    </>
+    <div css={containerStyles}>
+      <Title title="로그인" part="login" />
+      <AuthForm />
+    </div>
   );
 }
 
 const containerStyles = css`
-  margin: 0 -16px 90px;
-  background: ${theme.palette.background.home};
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+  gap: 96px;
+  min-width: 280px;
+  max-width: 360px;
+
+  ${mq.md} {
+    max-width: 480px;
+  }
+  ${mq.lg} {
+    max-width: 640px;
+  }
+  ${mq.tab} {
+    max-width: 1024px;
+  }
 `;
 
-export default Home;
+export default Main;

--- a/src/pages/lunch/index.tsx
+++ b/src/pages/lunch/index.tsx
@@ -3,6 +3,7 @@ import Title from '@/components/common/Title';
 import LunchDetail from '@/components/lunch/detail';
 import LunchMainContents from '@/components/lunch/LunchMainContents';
 import LunchReviewsByRanking from '@/components/lunch/review/LunchReviewsByRanking';
+import COMPONENT_NAME from '@/constants/common/pages';
 import { HOME_TEXTS } from '@/constants/home/homeTexts';
 import usePagesStore from '@/stores/usePagesStore';
 import theme from '@/styles/theme';
@@ -11,13 +12,14 @@ import { css } from '@emotion/react';
 function LunchHome() {
   const { lunch } = HOME_TEXTS.title;
   const { nextComponent } = usePagesStore();
+  const { detail } = COMPONENT_NAME.lunch;
 
   // 오점완 홈 -> 리뷰 상세
   switch (nextComponent) {
-    case 'LunchDetail':
+    case detail.detail:
       return <LunchDetail />;
     // 오점완 홈 -> 랭킹별 리뷰
-    case 'LunchReviewsByRanking':
+    case detail.reviewByRanking:
       return <LunchReviewsByRanking />;
     default:
       return (

--- a/src/stores/useSaveStore.ts
+++ b/src/stores/useSaveStore.ts
@@ -9,6 +9,7 @@ type SaveStore = {
   isSave: Save;
   setIsSavePhotoMsg: () => void;
   clearIsSave: () => void;
+  setUserToken: (value: string) => void;
 };
 
 const initialSaveState = {
@@ -25,6 +26,9 @@ const useSaveStore = create<SaveStore>()(
         })),
       clearIsSave: () => {
         set({ isSave: initialSaveState });
+      },
+      setUserToken: (value: string) => {
+        localStorage.setItem('user', value);
       },
     }),
     {


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

## 👩‍🎤 작업 내용

`useSaveStore()`를 잘 구성해주신 덕분에 세터 함수 하나 추가해서
유저 클릭 시 로컬스토리지에 'user'라는 key로 토큰 저장합니다.

리렌더링 발생 시, 로컬 스토리지의 토큰 값의 유무를 대조하여 
로그인페이지를 렌딩할 지, 홈을 렌딩할 지를 `usePagesStore()`를 통해 조건부 렌더링 합니다.

![ezgif com-video-to-gif (32)](https://github.com/livable-final/client/assets/83483378/3d1007d2-cf68-434d-80f6-ecd233513969)




## 🧚 관련 issue

closed #115 


## 🙋🏼 공유할 사항 및 질문 사항

SSR에서는 브라우저의 로컬스토리지나 쿠키에 접근할 수 없다는 것을 알면서도 접근시켜보려고 하다가 너무 시간을 허비했네요.
이론상 불가능한 것 같습니다 껄껄

더 이상 시간을 허비하고 싶지 않아서 오점으로 남았지만.. 새로고침 시 로컬 스토리지에 유효한 토큰 값이 있어도.
SSR에서 로컬 스토리지에 접근할 수 없기 때문에 매우 짧은 시간 로그인 컴포넌트가 보였다가 그 즉시 CSR을 통해 다시 홈 컴포넌트로 렌더되는 모습을 보실 수 있을 겁니다 ㅠ_ㅠ